### PR TITLE
Locking @sveltejs/kit version due to build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^1.0.0-next.26",
-    "@sveltejs/kit": "next",
+    "@sveltejs/kit": "1.0.0-next.232",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
     "eslint": "^7.32.0",


### PR DESCRIPTION
There is an issue introduced by @svelteajs/kit that causes builds to fail with the below. Locking the version for now.

```shell
> Using @sveltejs/adapter-static
> body used already for:
```