### PR TITLE
Fix title's to be correct during SSR, add additional metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "remark-gfm": "^3.0.0",
         "remark-parse": "^10.0.0",
         "remark-rehype": "^10.0.0",
+        "schema-dts": "^1.1.0",
         "svelte": "^3.49.0",
         "svelte-check": "^2.8.0",
         "svelte-eslint-parser": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "remark-gfm": "^3.0.0",
     "remark-parse": "^10.0.0",
     "remark-rehype": "^10.0.0",
+    "schema-dts": "^1.1.0",
     "svelte": "^3.49.0",
     "svelte-check": "^2.8.0",
     "svelte-eslint-parser": "^0.17.0",

--- a/src/components/Title.svelte
+++ b/src/components/Title.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { metadata } from '$lib/metadata';
+	import { MetaTags } from 'svelte-meta-tags';
+	import type { OpenGraph } from 'svelte-meta-tags';
+	export let title: string;
+	export let description: string;
+	export let openGraph: OpenGraph | undefined = undefined;
+
+	metadata.set({
+		title: title,
+		description: description
+	});
+</script>
+
+<MetaTags
+	title={$metadata.title}
+	titleTemplate="%s | Alex Dobin"
+	description={$metadata.description}
+	{openGraph}
+/>

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -42,7 +42,9 @@ export async function process(fileName: string): Promise<BlogPost> {
 		const file = await parser.process(await toVFile.read(fileName));
 		assertMetadata(file.data);
 		// Format the date
-		file.data.date = dayjs(file.data.date).format('MMM D, YYYY');
+		file.data.dateDisplay = dayjs(file.data.date).format('MMM D, YYYY');
+		// Add the slug information into the metadata
+		file.data.slug = file.basename.slice(0, -3);
 		return {
 			metadata: file.data,
 			html: String(file),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,10 +1,12 @@
 export interface BlogPost {
 	metadata: {
 		title: string;
+		dateDisplay: string;
 		date: string;
 		draft: boolean;
 		description: string;
 		tags: string[];
+		slug: string;
 	};
 	html: string;
 	fileName: string;

--- a/src/posts/first-post.md
+++ b/src/posts/first-post.md
@@ -1,12 +1,10 @@
 ---
-title: First post
+title: Creating a blog
 date: 2022/02/21
 draft: false
 description: Creating a blog!
 tags:
   - intro
 ---
-
-# Creating a blog
 
 I have been building a [homelab](https://www.reddit.com/r/homelab/wiki/introduction) for the last few years, mostly to [self-host](https://www.reddit.com/r/selfhosted/) services securely at home without relying on the major cloud providers. I've learned a lot going through the experience and wanted to start sharing some of the knowledge back to the community outside of a few tiny pull requests that I've made. Look for more coming soon!

--- a/src/posts/tailscale-hostnames-for-pi-hole-stats.md
+++ b/src/posts/tailscale-hostnames-for-pi-hole-stats.md
@@ -8,7 +8,6 @@ tags:
   - pi-hole
   - magicdns
 ---
-# Pi-hole + Tailscale
 [Tailscale](https://tailscale.com) is a fantastic secure mesh VPN that lets you connect all of your devices to each other, no matter where they are or if you've exposed them publicly to the internet. I use it extensively to use all my homelab services and run it on virtually every server. They have a very generous free tier and hope that enthusiasts enjoy it so much that they bring it to their workplace.
 
 Tailscale publishes a great [article](https://tailscale.com/kb/1114/pi-hole/) on how to use a [Pi-hole](https://pi-hole.net/) as the DNS server on your tailnet, allowing you to fully control the DNS of your device no matter what network you are connected to while leveraging their Magic DNS to connect to the other devices on your tailnet. One thing it doesn't cover is how to reenable conditional forwarding for your Pi-hole so that your statistics are not full of your Tailscale assigned `100.x.x.x` addresses but instead show the machines hostname.

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import Nav from '../components/Nav.svelte';
 	import { invalidate } from '$app/navigation';
-	import { MetaTags } from 'svelte-meta-tags';
-	import { metadata } from '$lib/metadata';
 
 	if (import.meta.hot) {
 		import.meta.hot.on('content-update', (data) => {
@@ -13,8 +11,6 @@
 		});
 	}
 </script>
-
-<MetaTags title={`${$metadata.title} | Alex Dobin`} description={$metadata.description} />
 
 <Nav />
 

--- a/src/routes/about.svelte
+++ b/src/routes/about.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-	import { metadata } from '$lib/metadata';
-
-	metadata.set({
-		title: 'About',
-		description: 'About Alex Dobin'
-	});
+	import Title from '../components/Title.svelte';
 </script>
+
+<Title title="About" description="About Alex Dobin" />
 
 <h1>About Alex</h1>
 

--- a/src/routes/blog.svelte
+++ b/src/routes/blog.svelte
@@ -1,28 +1,27 @@
 <script lang="ts">
 	import type { BlogPost } from '$lib/types';
-	import { metadata } from '$lib/metadata';
-	export let posts: BlogPost[];
-
-	metadata.set({
-		title: 'Blog',
-		description: 'A collection of my blog posts.'
-	});
+	import dayjs from 'dayjs';
+	import Title from '../components/Title.svelte';
+	export let posts: BlogPost['metadata'][];
 </script>
+
+<Title title="Blog" description="A collection of my blog posts" />
 
 <h1>Recent posts</h1>
 
 <ul>
 	{#each posts as post}
 		<li
-			><a href="blog/{post.slug}">{post.metadata.title}</a><div class="date"
-				>{post.metadata.date}</div
-			><div>{post.metadata.description}</div></li
+			><a href="blog/{post.slug}">{post.title}</a><br />
+			<time datetime={dayjs(post.date).format('YYYY-MM-DD')}>{post.dateDisplay}</time><div
+				>{post.description}</div
+			></li
 		>
 	{/each}
 </ul>
 
 <style>
-	.date {
+	time {
 		font-style: italic;
 	}
 

--- a/src/routes/blog.ts
+++ b/src/routes/blog.ts
@@ -2,11 +2,11 @@ import type { BlogPost } from '$lib/types';
 import { loadPosts, processBlogIndex } from './blog/_posts';
 import type { RequestHandler } from './__types/blog';
 
-export const GET: RequestHandler<{ posts: BlogPost[] }> = async () => {
+export const GET: RequestHandler<{ posts: BlogPost['metadata'][] }> = async () => {
 	return {
 		status: 200,
 		body: {
-			posts: await processBlogIndex(await loadPosts())
+			posts: (await processBlogIndex(await loadPosts())).map((post) => post.metadata)
 		}
 	};
 };

--- a/src/routes/blog/[slug].svelte
+++ b/src/routes/blog/[slug].svelte
@@ -1,21 +1,65 @@
 <script lang="ts">
 	import type { BlogPost } from '$lib/types';
-	import { metadata } from '$lib/metadata';
 	import 'highlight.js/styles/default.css';
+	import dayjs from 'dayjs';
+	import Title from '../../components/Title.svelte';
+	import { JsonLd } from 'svelte-meta-tags';
+	import type { Article } from 'schema-dts';
 	export let post: BlogPost;
 
-	metadata.set({
-		title: post.metadata.title,
-		description: post.metadata.description
-	});
+	const article: Article = {
+		'@type': 'Article',
+		headline: post.metadata.title,
+		description: post.metadata.description,
+		author: {
+			'@type': 'Person',
+			name: 'Alex Dobin',
+			worksFor: 'Microsoft'
+		},
+		datePublished: dayjs(post.metadata.date).toISOString(),
+		dateModified: dayjs(post.metadata.date).toISOString(),
+		publisher: {
+			'@type': 'Person',
+			name: 'Alex Dobin',
+			worksFor: 'Microsoft'
+		}
+	};
 </script>
 
-<div class="content">
+<Title
+	title={post.metadata.title}
+	description={post.metadata.description}
+	openGraph={{
+		title: post.metadata.title,
+		description: post.metadata.description,
+		url: `https://alexdobin.dev/blog/${post.metadata.slug}`,
+		type: 'article',
+		article: {
+			publishedTime: dayjs(post.metadata.date).toISOString(),
+			modifiedTime: dayjs(post.metadata.date).toISOString(),
+			section: 'Technology',
+			tags: post.metadata.tags
+		}
+	}}
+/>
+
+<JsonLd schema={article} />
+
+<section class="content">
+	<h1>{post.metadata.title}</h1>
+	<p class="published-date"
+		>First published <time datetime={dayjs(post.metadata.date).format('YYYY-MM-DD')}
+			>{post.metadata.dateDisplay}</time
+		></p
+	>
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 	{@html post.html}
-</div>
+</section>
 
 <style>
+	.published-date {
+		font-style: italic;
+	}
 	/*
 		By default, CSS is locally scoped to the component,
 		and any unused styles are dead-code-eliminated.

--- a/src/routes/blog/_posts.ts
+++ b/src/routes/blog/_posts.ts
@@ -34,10 +34,7 @@ function loadPost(fileName: string): Promise<BlogPost> {
 async function processBlogIndex(posts: Map<string, BlogPost>): Promise<BlogPost[]> {
 	const postList = posts.values();
 	return Array.from(postList)
-		.sort(
-			(a, b) =>
-				dayjs(b.metadata.date, 'MMM D, YYYY').unix() - dayjs(a.metadata.date, 'MMM D, YYYY').unix()
-		)
+		.sort((a, b) => dayjs(b.metadata.date).unix() - dayjs(a.metadata.date).unix())
 		.filter((post) => dev || !post.metadata.draft);
 }
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-	import { metadata } from '$lib/metadata';
-
-	metadata.set({
-		title: 'Home',
-		description: 'Welcome to Alex Dobin!'
-	});
+	import Title from '../components/Title.svelte';
 </script>
+
+<Title title="Home" description="Welcome to Alex Dobin" />
 
 <h1>Alex Dobin</h1>
 


### PR DESCRIPTION
- During SSR and static generation the original titles of the pages were the previous values because it wasn't being updated until the page was mounted and the store was updating the layout components. This moves setting the values to each page so that the value is correct on the original load.
- Adding OpenGraph and JSON-LD metadata to improve the experience linking to blog posts