### PR TITLE
Stop kodiak from removing automerge labels

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -10,6 +10,7 @@ auto_approve_usernames = ["dependabot", "ADobin"]
 [merge]
 automerge_label = "ship it!"
 method = "squash"
+notify_on_conflict = false
 
 [merge.automerge_dependencies]
 # auto merge all PRs opened by "dependabot" that are "minor" or "patch" version upgrades. "major" version upgrades will be ignored.


### PR DESCRIPTION
Stop kodiak from removing automerge labels