### PR TITLE
fix(blog): fix links for blogs with latest SvelteKit versions

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,16 @@
     "singleQuote": true,
     "trailingComma": "none",
     "printWidth": 100,
-    "htmlWhitespaceSensitivity": "strict"
+    "htmlWhitespaceSensitivity": "strict",
+    "plugins": [
+        "prettier-plugin-svelte"
+    ],
+    "overrides": [
+        {
+            "files": "*.svelte",
+            "options": {
+                "parser": "svelte"
+            }
+        }
+    ]
 }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -8,9 +8,7 @@ import type { BlogPost } from '$lib/types';
 async function loadPosts(): Promise<Map<string, BlogPost>> {
 	const postMap = new Map<string, BlogPost>();
 	await Promise.all(
-		(
-			await readdir('src/posts')
-		)
+		(await readdir('src/posts'))
 			.filter((fileName) => /.+\.md$/.test(fileName))
 			.map(async (fileName) => {
 				const post = await loadPost(fileName);

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { dev } from '$app/environment';
 	import { page } from '$app/stores';
 </script>
 

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { PageData } from './$types';
+	import { base } from '$app/paths';
 	import dayjs from 'dayjs';
 	import Title from '../../components/Title.svelte';
 	export let data: PageData;
@@ -9,13 +10,13 @@
 
 <div class="header">
 	<h1>Recent posts</h1>
-	<a href="blog/rss.xml"><img class="mark" src="rss.png" alt="rss" /></a>
+	<a href="{base}/blog/rss.xml"><img class="mark" src="{base}/rss.png" alt="rss" /></a>
 </div>
 
 <ul>
 	{#each data.posts as post}
 		<li
-			><a href="blog/{post.slug}">{post.title}</a><br />
+			><a href="{base}/blog/{post.slug}">{post.title}</a><br />
 			<time datetime={dayjs(post.date).format('YYYY-MM-DD')}>{post.dateDisplay}</time><div
 				>{post.description}</div
 			></li


### PR DESCRIPTION
Blog links were resolving inconsistently in dev and incorrectly on deployments. This forces them to use full paths `{base}/` instead, which is not ideal but needs to be investigated further.

- small update to handle new prettier versions correctly
- fixes for new prettier rules