### PR TITLE
Disable GitHub Actions dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,12 +22,12 @@ updates:
       typescript-eslint:
         patterns:
           - '@typescript-eslint/*'
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    labels:
-      - 'dependencies'
-      # Add Kodiak `merge.automerge_label`
-      - 'ship it!'
-    schedule:
-      # Check for updates to GitHub Actions every weekday
-      interval: 'daily'
+#  - package-ecosystem: 'github-actions'
+#    directory: '/'
+#    labels:
+#      - 'dependencies'
+#      # Add Kodiak `merge.automerge_label`
+#      - 'ship it!'
+#    schedule:
+#      # Check for updates to GitHub Actions every weekday
+#      interval: 'daily'


### PR DESCRIPTION
Comment out GitHub Actions dependency configuration. This is currently breaking Matrix and I don't have time at the moment to fix the action to create my own deployment file.