### PR TITLE
ci: use .node-version file for CI node setup

### DIFF
--- a/.github/workflows/build_deploy_gh_pages.yml
+++ b/.github/workflows/build_deploy_gh_pages.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: "20.11.x"
+          node-version-file: ".node-version"
           cache: "npm"
 
       - name: Install and Build 🔧


### PR DESCRIPTION
Replace hardcoded `node-version: 20.11.x` with `node-version-file: .node-version` so CI automatically stays in sync with the project's pinned Node version.

This is needed before the dependabot eleventy-plugin-vento upgrade (PR #1279) can pass, since vento 5.4.x requires Node 22+.